### PR TITLE
Removed pipe for picard step; added tmp_dir parameter

### DIFF
--- a/unpack_bam.pl
+++ b/unpack_bam.pl
@@ -135,7 +135,7 @@ warn "STATUS: Parsed " . scalar( @rg_lines ) . " \@RG lines from BAM and wrote t
 
 # Unless FASTQs already exist, use Picard to revert BQ scores, and create FASTQs; then zip em up
 unless( $skip_picard ) {
-    my $temp_filename = getcwd."/".basename($bam_file).".temp_file";
+    my $temp_filename = $output_dir."/".basename($bam_file).".temp_file";
     my $cmd = "$java_bin -Xmx6g -jar $picard_jar RevertSam TMP_DIR=$tmp_dir INPUT=$bam_file OUTPUT=$temp_filename SANITIZE=true COMPRESSION_LEVEL=0 VALIDATION_STRINGENCY=SILENT; java -Xmx6g -jar $picard_jar SamToFastq TMP_DIR=$tmp_dir INPUT=$temp_filename OUTPUT_PER_RG=true RG_TAG=$rg_tag OUTPUT_DIR=$output_dir VALIDATION_STRINGENCY=SILENT";
     print "RUNNING: $cmd\n";
     print `$cmd`;

--- a/unpack_bam.pl
+++ b/unpack_bam.pl
@@ -8,7 +8,7 @@
 # modified on June 3, 2019
 # purpose: (1) Re-set default path of java, samtools, and picard's jar file; (2) Added input option of "picard-jar"
 # 
-# AUTHOR: Cyriac Kandoth (ckandoth@gmail.com); Zuojian Tang (zuojian.tang@gmail.com); Allan Bolipat (allan.bolipata@gmail.com)
+# AUTHOR: Cyriac Kandoth (ckandoth@gmail.com); Zuojian Tang (zuojian.tang@gmail.com); Allan Bolipata (allan.bolipata@gmail.com)
 
 use warnings; # Tells Perl to show warnings on anything that might not work as expected
 use strict; # Tells Perl to show errors if any of our code is ambiguous

--- a/unpack_bam.pl
+++ b/unpack_bam.pl
@@ -139,6 +139,7 @@ unless( $skip_picard ) {
     print `$cmd`;
     print "RUNNING: gzip $output_dir/*.fastq\n";
     print `gzip $output_dir/*.fastq`;
+    print `rm $temp_filename`;
 }
 
 # Make sure FASTQs follow the Illumina/Casava naming scheme, and move them into per-RG subfolders

--- a/unpack_bam.pl
+++ b/unpack_bam.pl
@@ -7,6 +7,8 @@
 # purpose: (1) Extract flowcell/lane information from first read ID of the @RG using @RG's ID; (2) Picard uses PU as fastq files's name if PU does not following the standard format. We need to consider this situation.
 # modified on June 3, 2019
 # purpose: (1) Re-set default path of java, samtools, and picard's jar file; (2) Added input option of "picard-jar"
+# modified on June 6, 2019
+# purpose: (1) Added option to set temp directory; (2) Changed pipe and /dev/stdout /dev/stdin logic in picard step
 # 
 # AUTHOR: Cyriac Kandoth (ckandoth@gmail.com); Zuojian Tang (zuojian.tang@gmail.com); Allan Bolipata (allan.bolipata@gmail.com)
 
@@ -26,7 +28,7 @@ my $samtools_bin = "samtools";
 my $picard_jar = "/opt/common/CentOS_6-dev/picard/v2.13/picard.jar";
 
 # Default temp directory for compatibility with old usage
-my $tmp_dir = "/scratch"
+my $tmp_dir = "/scratch";
 
 # Check for missing or crappy arguments
 unless( @ARGV and $ARGV[0]=~m/^-/ ) {
@@ -183,6 +185,7 @@ __DATA__
  --input-bam      Path to the BAM file to unpack
  --output-dir     Path to output directory where FASTQs and readgroup info files will be stored
  --sample-id      Sample ID for the BAM. Any sample ID in the readgroup data is ignored
+ --tmp-dir        Path for temp directory used by picard; defaults to "/scratch"
  --picard-jar     Path to the Picard Jar file
  --help           Print a brief help message and quit
  --man            Print the detailed manual


### PR DESCRIPTION
First, the paths `/dev/stdout` and `/dev/stdin` used by the picard step causes problems in the container. I believe it's because `/dev/` is a location in the container that's not easily writeable.

Instead [I have `unpack_bam.pl` create a temp file](https://github.com/mskcc/cmo-scripts/compare/feature/containerize_unpack_bam?expand=1#diff-6f262043e9fa1a4e29ed33d4d70b2da5R136) instead of using the pipe.

Second, the `/scratch` directory was hard-coded in; [I removed it and changed it to a `$tmp_dir` parameter](https://github.com/mskcc/cmo-scripts/compare/feature/containerize_unpack_bam?expand=1#diff-6f262043e9fa1a4e29ed33d4d70b2da5R137); it's actually [set to default as `/scratch`](https://github.com/mskcc/cmo-scripts/compare/feature/containerize_unpack_bam?expand=1#diff-6f262043e9fa1a4e29ed33d4d70b2da5R29), so it shouldn't affect what you guys are doing right now.

I don't have a test for this, so I've requested @Zuojian-Tang to run an example for me if she has the bandwidth.